### PR TITLE
Unset imports from the config array, when they are no longer needed

### DIFF
--- a/src/DerAlex/Silex/YamlConfigServiceProvider.php
+++ b/src/DerAlex/Silex/YamlConfigServiceProvider.php
@@ -64,6 +64,7 @@ class YamlConfigServiceProvider implements ServiceProviderInterface
                     $new_config = new YamlConfigServiceProvider($base_dir . $resource['resource']);
                     $new_config->register($app);
                 }
+                unset($config['imports']);
             }
         }
     }


### PR DESCRIPTION
To keep things more tight, I think we should unset the import directives, when files have been imported.
